### PR TITLE
[#3118] Check renegociate_pending instead of state_string.

### DIFF
--- a/ftplib/ftplib.py
+++ b/ftplib/ftplib.py
@@ -734,14 +734,14 @@ else:
             socket.set_shutdown(ssl.SENT_SHUTDOWN | ssl.RECEIVED_SHUTDOWN)
 
             # Don't close the socket unless negotiation is done.
-            while (
-                    socket.state_string() !=
-                    'SSL negotiation finished successfully'
-                ):
+            while True:
                 try:
                     socket.do_handshake()
                 except ssl.WantReadError:
                     pass
+
+                if not socket.renegotiate_pending():
+                    break
 
             done = socket.shutdown()
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Package definition for chevah.ftpslib.
 from setuptools import Command, setup
 import os
 
-VERSION = '2.7.3.c7'
+VERSION = '2.7.3.c7.1'
 
 
 class PublishCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Package definition for chevah.ftpslib.
 from setuptools import Command, setup
 import os
 
-VERSION = '2.7.3.c7.1'
+VERSION = '2.7.3.c8'
 
 
 class PublishCommand(Command):


### PR DESCRIPTION
## Problem

The `state_string` is no longer updated and is `None` according to my tests and our `doSSLShutdown` loop never terminates.

Due to this functional tests are hanging after `OpenSSL` upgrade.
## Changes

I've refactored the code to wait until `renegotiate_pending` is `False`.

Unfortunately this does not have the same effect as the previous code. Until we find an altenative it will have to do. Given the above reason I have not bumped the version but added another part instead.
## How to test

reviewers @adiroiban 

Please check that changes make sense. Thanks.
